### PR TITLE
use hyphenated composer package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "wikibase/WikimediaBadges",
+	"name": "wikibase/wikimedia-badges",
 	"description": "Extension which contains default themes to display badges on Wikimedia projects",
 	"type": "mediawiki-extension",
 	"version": "0.1-alpha",


### PR DESCRIPTION
"it's encouraged to use a dash (-) as separator instead of CamelCased names" --https://packagist.org/about
