### PR TITLE
Do not autoload the entry point in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
 		"php": ">=5.3.0"
 	},
 	"autoload": {
-		"files": [
-			"WikimediaBadges.php"
-		],
 		"classmap": [
 			"WikimediaBadges.hooks.php"
 		]


### PR DESCRIPTION
This does not work with our build setup, in cases where only the repo is installed. (e.g. as used to be the setup on Wikidata)

Instead we need to explicitly require_once the entry point.
