### PR TITLE
Do not fail if client is not installed

### DIFF
--- a/WikimediaBadges.php
+++ b/WikimediaBadges.php
@@ -32,10 +32,6 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 $GLOBALS['wgExtensionFunctions'][] = function() {
 	global $wgExtensionCredits, $wgMessagesDirs, $wgHooks, $wgResourceModules;
 
-	if ( !defined( 'WBC_VERSION' ) ) {
-		throw new Exception( 'The WikimediaBadges extension requires Wikibase Client to be installed.' );
-	}
-
 	$wgExtensionCredits['wikibase'][] = array(
 		'path' => __DIR__,
 		'name' => 'WikimediaBadges',


### PR DESCRIPTION
There is nothing here that is actually dependent on Wikibase, so no need for hard failure.
