### PR TITLE
Revert "Remove internationalization"

### DIFF
--- a/WikimediaBadges.php
+++ b/WikimediaBadges.php
@@ -38,8 +38,11 @@ $GLOBALS['wgExtensionFunctions'][] = function() {
 		'version' => WIKIMEDIA_BADGES_VERSION,
 		'author' => '[[mw:User:Bene*|Bene*]]',
 		'url' => 'https://github.com/wmde/WikimediaBadges',
-		'description' => 'Extension which contains default themes to display badges on Wikimedia projects'
+		'descriptionmsg' => 'wikimedia-badges-desc'
 	);
+
+	// i18n
+	$wgMessagesDirs['WikimediaBadges'] = __DIR__ . '/i18n';
 
 	// Hooks
 	$wgHooks['BeforePageDisplay'][] = 'WikimediaBadges\Hooks::onBeforePageDisplay';

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,8 @@
+{
+	"@metadata": {
+		"authors": [
+			"Bene*"
+		]
+	},
+	"wikimedia-badges-desc": "Extension which contains default themes to display badges on Wikimedia projects"
+}

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -1,0 +1,8 @@
+{
+	"@metadata": {
+		"authors": [
+			"Bene*"
+		]
+	},
+	"wikimedia-badges-desc": "{{desc|name=WikimediaBadges|url=https://github.com/wmde/WikimediaBadges}}"
+}


### PR DESCRIPTION
Hardcoding English text is not the way to fix
messages not appearing.

This reverts commit 6cb8e19b7b7573745d06db754aefc26166f093a5.
